### PR TITLE
Fix conversion to ros2, because of rosbags version change

### DIFF
--- a/python/vbr_devkit/tools/run.py
+++ b/python/vbr_devkit/tools/run.py
@@ -75,13 +75,20 @@ def convert(to: Annotated[OutputDataInterface, typer.Argument(help="Desired data
                     show_default=True)] = True) -> None:
     console.print(f"Converting {input_dir} to {to} format at {output_dir}")
     if to == OutputDataInterface.ros2:
-        if not input_dir.is_dir():
-            print("Processing...")
-            rosconvert.convert(input_dir, output_dir / input_dir.stem)
-        else:
-            for item in track(list(input_dir.iterdir()), description="Processing..."):
-                if item.suffix == '.bag':
-                    rosconvert.convert(item, output_dir / item.stem)
+        print("Processing...")
+        rosconvert.convert(
+            sorted([f for f in input_dir.glob("*.bag")]) if input_dir.is_dir() else [input_dir],
+            output_dir / input_dir.stem,
+            dst_version=None,
+            compress=None,
+            compress_mode="file",
+            default_typestore=None,
+            typestore=None,
+            exclude_topics=[],
+            include_topics=[],
+            exclude_msgtypes=[],
+            include_msgtypes=[]
+        )
     else:
         with RosReader(input_dir) as reader:
             with OutputDataInterface_lut[to](output_dir, rgb_convert=rgb_conversion,


### PR DESCRIPTION
Trying to convert the data to ros2 throws an error seemingly because of rosbags version change from 0.9.x to 0.10.x. The change is pretty simple which I suggest here, or the alternative can be to just pin the version in `pyproject.toml`.

For example, running (with main commit b422314)

```bash
vbr convert ros2 campus_train0 ros2_campus_train0
```

throws the error

```bash
File ".../vbr-devkit/python/vbr_devkit/tools/run.py", line 84, in convert
    rosconvert.convert(item, output_dir / item.stem)
TypeError: convert() missing 9 required positional arguments: 'dst_version', 'compress', 'compress_mode', 'default_typestore', 'typestore', 'exclude_topics', 'include_topics', 'exclude_msgtypes', and 'include_msgtypes'
```

I suggest two changes:
- I kept the defaults for all the additional arguments to `rosconvert.convert()`. 
- And because rosbags can handle split ros1 bag files, I changed the if-else conditional to allow passing a list of bags to convert() instead of converting each bag individually.